### PR TITLE
Fix "Uninitialized string offset: 0" when installing module for the first time

### DIFF
--- a/teemip-ip-mgmt/module.teemip-ip-mgmt.php
+++ b/teemip-ip-mgmt/module.teemip-ip-mgmt.php
@@ -125,6 +125,10 @@ if (!class_exists('IPManagementInstaller'))
 		 */
 		public static function AfterDatabaseCreation(Config $oConfiguration, $sPreviousVersion, $sCurrentVersion)
 		{
+			if ($sPreviousVersion === '') {
+				return;
+			}
+
 			$sDBSubname = $oConfiguration->Get('db_subname');
 			if (($sPreviousVersion == '2.5.0') || ($sPreviousVersion == '2.5.1')) {
 				SetupLog::Info("Module teemip-ip-mgmt: reset next_run_date of ReleaseIPsFromObsoleteCIs backgorund task");


### PR DESCRIPTION
Error occurs during setup

Was caused by \IPManagementInstaller::AfterDatabaseCreation