### PR TITLE
Fix SQL column expression for AttributeIPv6Address

### DIFF
--- a/teemip-ipv6-mgmt/src/Model/AttributeIPv6Address.php
+++ b/teemip-ipv6-mgmt/src/Model/AttributeIPv6Address.php
@@ -147,8 +147,8 @@ class AttributeIPv6Address extends AttributeString
 	public function GetSQLColumns($bFullSpec = false)
 	{
 		$aColumns = array();
-		$aColumns[$this->GetCode().'_text'] = 'CHAR(39)';
-		$aColumns[$this->GetCode().'_comp'] = 'CHAR(39)';
+		$aColumns[$this->GetCode().'_text'] = 'CHAR(39)'.CMDBSource::GetSqlStringColumnDefinition();
+		$aColumns[$this->GetCode().'_comp'] = 'CHAR(39)'.CMDBSource::GetSqlStringColumnDefinition();
 
 		return $aColumns;
 	}
@@ -276,7 +276,7 @@ class AttributeIPv6Address extends AttributeString
 	public function GetImportColumns()
 	{
 		$aColumns = array();
-		$aColumns[$this->GetCode()] = 'CHAR(39)';
+		$aColumns[$this->GetCode()] = 'CHAR(39)'.CMDBSource::GetSqlStringColumnDefinition();
 
 		return $aColumns;
 	}


### PR DESCRIPTION
This eliminates the following kind of messages in the toolkit:
<img width="1205" alt="image" src="https://github.com/TeemIp/teemip-core-ip-mgmt/assets/228588/a5f340ba-e8b4-40f5-96d2-f1526f0b163e">
