### PR TITLE
Restore iTop 3.0 compatibility for VirtualMachine presentation

### DIFF
--- a/teemip-virtualization-mgmt-adaptor/datamodel.teemip-virtualization-mgmt-adaptor.xml
+++ b/teemip-virtualization-mgmt-adaptor/datamodel.teemip-virtualization-mgmt-adaptor.xml
@@ -52,7 +52,7 @@
         </search>
         <summary>
           <items>
-            <item id="managementip" _delta="delete"/>
+            <item id="managementip" _delta="delete_if_exists"/>
             <item id="managementip_id" _delta="define">
               <rank>30</rank>
             </item>

--- a/teemip-virtualization-mgmt-adaptor/module.teemip-virtualization-mgmt-adaptor.php
+++ b/teemip-virtualization-mgmt-adaptor/module.teemip-virtualization-mgmt-adaptor.php
@@ -6,7 +6,7 @@
 
 SetupWebPage::AddModule(
 	__FILE__,
-	'teemip-virtualization-mgmt-adaptor/3.1.1',
+	'teemip-virtualization-mgmt-adaptor/3.1.2',
 	array(
 		// Identification
 		//


### PR DESCRIPTION
The summary card doesn't exist on iTop 3.0, so delta `delete` would fail, hence replaced by `delete_if_exists`.

Incompatibility was introduced with #26 ([release 3.1.3](https://github.com/TeemIp/teemip-core-ip-mgmt/releases/tag/3.1.3))