### PR TITLE
feat(VLAN): Replace all different interface lists for a single tab

### DIFF
--- a/teemip-network-mgmt/datamodel.teemip-network-mgmt.xml
+++ b/teemip-network-mgmt/datamodel.teemip-network-mgmt.xml
@@ -2031,13 +2031,65 @@
           <ext_key_to_remote>networkdevicevirtualinterface_id</ext_key_to_remote>
           <duplicates/>
         </field>
+        <field id="interfaces_list" xsi:type="AttributeDashboard" _delta="define" >
+          <definition>
+            <title>Class:VLAN/Attribute:interfaces_list+</title>
+            <cells>
+              <cell id="1">
+                <rank>10</rank>
+                <dashlets>
+                  <dashlet id="physicalinterfaces_list" xsi:type="DashletObjectList">
+                    <rank>10</rank>
+                    <title>Class:VLAN/Attribute:physicalinterfaces_list</title>
+                    <query><![CDATA[SELECT lnkPhysicalInterfaceToVLAN WHERE vlan_id = :this->id]]></query>
+                    <menu>true</menu>
+                  </dashlet>
+                </dashlets>
+              </cell>
+              <cell id="2">
+                <rank>20</rank>
+                <dashlets>
+                  <dashlet id="logicalinterfaces_list" xsi:type="DashletObjectList">
+                    <rank>10</rank>
+                    <title>Class:VLAN/Attribute:logicalinterfaces_list</title>
+                    <query><![CDATA[SELECT lnkLogicalInterfaceToVLAN WHERE vlan_id = :this->id]]></query>
+                    <menu>true</menu>
+                  </dashlet>
+                </dashlets>
+              </cell>
+              <cell id="3">
+                <rank>30</rank>
+                <dashlets>
+                  <dashlet id="networkdevicevirtualinterfaces_list" xsi:type="DashletObjectList">
+                    <rank>10</rank>
+                    <title>Class:VLAN/Attribute:networkdevicevirtualinterfaces_list</title>
+                    <query><![CDATA[SELECT lnkNetworkDeviceVirtualInterfaceToVLAN WHERE vlan_id = :this->id]]></query>
+                    <menu>true</menu>
+                  </dashlet>
+                </dashlets>
+              </cell>
+              <cell id="4">
+                <rank>40</rank>
+                <dashlets>
+                  <dashlet id="aggregatelinks_list" xsi:type="DashletObjectList">
+                    <rank>10</rank>
+                    <title>Class:VLAN/Attribute:aggregatelinks_list</title>
+                    <query><![CDATA[SELECT lnkAggregateLinkToVLAN WHERE vlan_id = :this->id]]></query>
+                    <menu>true</menu>
+                  </dashlet>
+                </dashlets>
+              </cell>
+            </cells>
+          </definition>
+        </field>
       </fields>
       <presentation>
         <details>
           <items>
-            <item id="networkdevicevirtualinterfaces_list" _delta="define">
-              <rank>70</rank>
+            <item id="interfaces_list" _delta="define">
+              <rank>50</rank>
             </item>
+            <item id="physicalinterfaces_list" _delta="delete_if_exists"/>
           </items>
         </details>
       </presentation>

--- a/teemip-network-mgmt/dictionaries/en.dict.teemip-network-mgmt.php
+++ b/teemip-network-mgmt/dictionaries/en.dict.teemip-network-mgmt.php
@@ -378,6 +378,8 @@ Dict::Add('EN US', 'English', 'English', array(
 	'Class:VLAN/Attribute:physicalinterface_list+' => 'List of all physical network interfaces attached to the VLAN',
 	'Class:VLAN/Attribute:networkdevicevirtualinterfaces_list' => 'Network device virtual interfaces',
 	'Class:VLAN/Attribute:networkdevicevirtualinterfaces_list+' => 'List of all network device virtual interfaces attached to the VLAN',
+	'Class:VLAN/Attribute:interfaces_list' => 'Network interfaces',
+	'Class:VLAN/Attribute:interfaces_list+' => 'List of all network interfaces attached to this VLAN',
 ));
 
 //

--- a/teemip-virtualization-mgmt-adaptor/datamodel.teemip-virtualization-mgmt-adaptor.xml
+++ b/teemip-virtualization-mgmt-adaptor/datamodel.teemip-virtualization-mgmt-adaptor.xml
@@ -475,15 +475,6 @@
           <duplicates/>
         </field>
       </fields>
-      <presentation>
-        <details>
-          <items>
-            <item id="logicalinterfaces_list" _delta="define">
-              <rank>60</rank>
-            </item>
-          </items>
-        </details>
-      </presentation>
     </class>
     <class id="VRF" _delta="must_exist">
       <fields>


### PR DESCRIPTION
This will give better overview on the different tabs on the VLAN objects.

<img width="936" height="292" alt="image" src="https://github.com/user-attachments/assets/3affa866-ff48-465f-87f9-613f905b376e" />
